### PR TITLE
Remove persisted "measured" state

### DIFF
--- a/Collapsible.js
+++ b/Collapsible.js
@@ -89,7 +89,7 @@ export default class Collapsible extends Component {
               this.setState(
                 {
                   measuring: false,
-                  measured: true,
+                  measured: false,
                   contentHeight: height,
                 },
                 () => callback(height)


### PR DESCRIPTION
This is the one-line fix required to allow Flash to use this library per its use case.